### PR TITLE
Fix error in onCommand

### DIFF
--- a/lib/POP3Server.js
+++ b/lib/POP3Server.js
@@ -175,7 +175,7 @@ POP3Server.prototype.onCommand = function(connection, request){
         params = cmd && request.substr(cmd[0].length+1);
 
     if(!cmd)
-        return this.respond("-ERR");
+        return connection.respond("-ERR");
 
     if(typeof this["cmd"+cmd[0].toUpperCase()]=="function"){
         return this["cmd"+cmd[0].toUpperCase()](connection, params && params.trim());

--- a/tests/test_POP3Server.js
+++ b/tests/test_POP3Server.js
@@ -276,6 +276,19 @@ describe('POP3 server', function(){
 		client.on('error', done);
 	});
 
+	it('Should error on invalid non-command strings', function(done){
+		var responses = [/^\+OK/, /^\-ERR/].reverse();
+		var client = net.connect(PORT);
+		client.on('error', function(err){
+			done(err);
+		});
+		client.on('data', function(chunk){
+			expect(chunk.toString('ascii')).to.match(responses.pop());
+			if(responses.length == 0) return done();
+			else client.write("9\r\n");
+		});
+	});
+
 	it('Should have persistent Deletions', function(done){
 		var client1 = new POP3Client(PORT, 'localhost', false);
 		var client2;


### PR DESCRIPTION
Sending simply "9\r\n" would crash the server before,
whereas it should just reply -ERR
